### PR TITLE
Use different Rust action and add caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust
-        uses: hecrj/setup-rust-action@v1
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Configure cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
         run: |


### PR DESCRIPTION
Just changing two things about your deployment setup that should make runs a bit faster:

- Use the GH Action from `dtolnay` to setup the Rust toolchain, which includes several auto-adjustments for convenience.
  - Enabled colored compile output.
  - Use the new sparse registry when supported by the toolchain.
  - Some other goodies and best practices for building in the CI.
- Add a popular cache to speed up future builds.
  - Using that one myself all the time, and works great.
  - Significantly speeds up the build & test step if there were no dependency changes.
